### PR TITLE
fix bounding box in viz

### DIFF
--- a/test/viz.cpp
+++ b/test/viz.cpp
@@ -33,7 +33,8 @@ struct Shape {
         auto maxX = std::numeric_limits<T>::min();
         auto minY = std::numeric_limits<T>::max();
         auto maxY = std::numeric_limits<T>::min();
-        for (const auto &pt : vertices) {
+        for (const auto &i : indices) {
+            auto& pt = vertices[i];
             if (pt[0] < minX) minX = pt[0];
             if (pt[1] < minY) minY = pt[1];
             if (pt[0] > maxX) maxX = pt[0];


### PR DESCRIPTION
fix of the bounding box used for opengl drawing. Otherwise it will use all vertices for the aabb calculation, even those that aren't actually result of the final triangulation. This caused visual alignment issues when comparing the output of earcut with libtess in viz before.