### PR TITLE
fix compiler warning (-Wshadow)

### DIFF
--- a/include/earcut.hpp
+++ b/include/earcut.hpp
@@ -90,8 +90,8 @@ private:
     class ObjectPool {
     public:
         ObjectPool() { }
-        ObjectPool(std::size_t blockSize) {
-            reset(blockSize);
+        ObjectPool(std::size_t blockSize_) {
+            reset(blockSize_);
         }
         ~ObjectPool() {
             clear();


### PR DESCRIPTION
Captured this while building GL native using @kkaefer's `cmake` branch:
```
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp:93:32: warning: declaration shadows a field of 'ObjectPool<T, Alloc>' [-Wshadow]
        ObjectPool(std::size_t blockSize) {
                               ^
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp:121:21: note: previous declaration is here
        std::size_t blockSize = 1;
                    ^
```