### PR TITLE
Fix compiler warning (-Wparentheses)

### DIFF
--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -666,8 +666,8 @@ template <typename N>
 bool Earcut<N>::intersects(const Node* p1, const Node* q1, const Node* p2, const Node* q2) {
     if ((equals(p1, q1) && equals(p2, q2)) ||
         (equals(p1, q2) && equals(p2, q1))) return true;
-    return area(p1, q1, p2) > 0 != area(p1, q1, q2) > 0 &&
-           area(p2, q2, p1) > 0 != area(p2, q2, q1) > 0;
+    return (area(p1, q1, p2) > 0) != (area(p1, q1, q2) > 0) &&
+           (area(p2, q2, p1) > 0) != (area(p2, q2, q1) > 0);
 }
 
 // check if a polygon diagonal intersects any polygon segments


### PR DESCRIPTION
Captured this while building Mapbox GL native GLFW test application on Ubuntu 16.04 i686:
```
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp: In constructor ‘mapbox::detail::Earcut<N>::ObjectPool<T, Alloc>::ObjectPool(std::size_t)’:
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp:93:43: warning: declaration of ‘blockSize’ shadows a member of ‘mapbox::detail::Earcut<N>::ObjectPool<T, Alloc>’ [-Wshadow]
         ObjectPool(std::size_t blockSize) {
                                           ^
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp:121:33: note: shadowed declaration is here
         std::size_t blockSize = 1;
                                 ^
In file included from ../../../src/mbgl/renderer/fill_bucket.cpp:11:0:
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp: In instantiation of ‘bool mapbox::detail::Earcut<N>::intersects(const mapbox::detail::Earcut<N>::Node*, const mapbox::detail::Earcut<N>::Node*, const mapbox::detail::Earcut<N>::Node*, const mapbox::detail::Earcut<N>::Node*) [with N = unsigned int]’:
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp:373:40:   required from ‘mapbox::detail::Earcut<N>::Node* mapbox::detail::Earcut<N>::cureLocalIntersections(mapbox::detail::Earcut<N>::Node*) [with N = unsigned int]’
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp:290:45:   required from ‘void mapbox::detail::Earcut<N>::earcutLinked(mapbox::detail::Earcut<N>::Node*, int) [with N = unsigned int]’
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp:176:17:   required from ‘void mapbox::detail::Earcut<N>::operator()(const Polygon&) [with Polygon = mbgl::GeometryCollection; N = unsigned int]’
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp:769:11:   required from ‘std::vector<_RealType> mapbox::earcut(const Polygon&) [with N = unsigned int; Polygon = mbgl::GeometryCollection]’
../../../src/mbgl/renderer/fill_bucket.cpp:75:63:   required from here
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp:669:33: warning: suggest parentheses around comparison in operand of ‘!=’ [-Wparentheses]
     return area(p1, q1, p2) > 0 != area(p1, q1, q2) > 0 &&
                                 ^
../../../mason_packages/headers/earcut/0.11/include/mapbox/earcut.hpp:670:33: warning: suggest parentheses around comparison in operand of ‘!=’ [-Wparentheses]
            area(p2, q2, p1) > 0 != area(p2, q2, q1) > 0;
                                 ^
```

Shadow declaration is fixed in https://github.com/mapbox/earcut.hpp/commit/e02a44d25a86bf46682cbe07139a7c0fa7cb962 - this adds the parentheses fix.

/cc @mourner