### PR TITLE
implicit size_t to int conversion

### DIFF
--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -184,7 +184,7 @@ typename Earcut<N>::Node*
 Earcut<N>::linkedList(const Ring& points, const bool clockwise) {
     using Point = typename Ring::value_type;
     double sum = 0;
-    const int len = points.size();
+    const int len = static_cast<int>(points.size());
     int i, j;
     Point p1, p2;
     Node* last = nullptr;


### PR DESCRIPTION
```
include/mapbox/earcut.hpp:187:21: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'const int' [-Werror,-Wshorten-64-to-32]

    const int len = points.size();
              ~~~   ^~~~~~~~~~~~~
```