### PR TITLE
fix division by zero #48

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ addons:
   apt:
     sources:
      - ubuntu-toolchain-r-test
-     - llvm-toolchain-precise-3.7
+     - llvm-toolchain-precise-3.8
      - george-edison55-precise-backports
     packages:
      - g++-4.9
      - gcc-4.9
-     - clang-3.7
+     - clang-3.8
      - cmake
      - cmake-data
      - xorg-dev
@@ -30,7 +30,7 @@ cache: apt
 
 before_script:
  - if [[ ${CXX} == "g++" ]]; then export CXX="g++-4.9" CC="gcc-4.9" ; fi
- - if [[ ${CXX} == "clang++" ]]; then export CXX="clang++-3.7" CC="clang-3.7" ; fi
+ - if [[ ${CXX} == "clang++" ]]; then export CXX="clang++-3.8" CC="clang-3.8" ; fi
 
 script:
  - mkdir ./build && cd ./build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ option(EARCUT_BUILD_VIZ "Build the earcut visualizer program" ON)
 
 # configure optimization
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(OPTIMIZATION_FLAGS "-O0") # optional: -fsanitize=signed-integer-overflow,undefined
+    set(OPTIMIZATION_FLAGS "-O0 -fsanitize=undefined")
     set(IS_DEBUG true)
     message("-- Configuring debug build")
 else()

--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -464,7 +464,7 @@ Earcut<N>::findHoleBridge(Node* hole, Node* outerNode) {
     // find a segment intersected by a ray from the hole's leftmost Vertex to the left;
     // segment's endpoint with lesser x will be potential connection Vertex
     do {
-        if (hy <= p->y && hy >= p->next->y) {
+        if (hy <= p->y && hy >= p->next->y && p->next->y != p->y) {
           double x = p->x + (hy - p->y) * (p->next->x - p->x) / (p->next->y - p->y);
           if (x <= hx && x > qx) {
             qx = x;
@@ -495,7 +495,7 @@ Earcut<N>::findHoleBridge(Node* hole, Node* outerNode) {
     double my = m->y;
 
     while (p != stop) {
-        if (hx >= p->x && p->x >= mx &&
+        if (hx >= p->x && p->x >= mx && hx != p->x &&
             pointInTriangle(hy < my ? hx : qx, hy, mx, my, hy < my ? qx : hx, hy, p->x, p->y)) {
 
             tanCur = std::abs(hy - p->y) / (hx - p->x); // tangential
@@ -699,7 +699,8 @@ bool Earcut<N>::middleInside(const Node* a, const Node* b) {
     double px = (a->x + b->x) / 2;
     double py = (a->y + b->y) / 2;
     do {
-        if (((p->y > py) != (p->next->y > py)) && (px < (p->next->x - p->x) * (py - p->y) / (p->next->y - p->y) + p->x))
+        if (((p->y > py) != (p->next->y > py)) && p->next->y != p->y &&
+                (px < (p->next->x - p->x) * (py - p->y) / (p->next->y - p->y) + p->x))
             inside = !inside;
         p = p->next;
     } while (p != a);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -70,8 +70,9 @@ void areaTest(const char *name, const Polygon &polygon, int expectedTriangles = 
         const auto &indices = tesselator.indices();
 
         const auto area = trianglesArea(vertices, indices);
-        const double deviation =
-            (expectedArea == 0 && area == 0) ? 0 : std::abs(area - expectedArea) / expectedArea;
+        const double deviation = (expectedArea == area) ? 0 :
+                expectedArea == 0 ? std::numeric_limits<double>::infinity() :
+                std::abs(area - expectedArea) / expectedArea;
 
         t.ok(deviation <= earcutDeviation, std::string{ "earcut deviation " } + formatPercent(deviation) +
                                                 " is less than " +
@@ -91,8 +92,9 @@ void areaTest(const char *name, const Polygon &polygon, int expectedTriangles = 
         const auto &indices = tesselator.indices();
 
         const auto area = trianglesArea(vertices, indices);
-        const double deviation =
-            (expectedArea == 0 && area == 0) ? 0 : std::abs(area - expectedArea) / expectedArea;
+        const double deviation = (expectedArea == area) ? 0 :
+                expectedArea == 0 ? std::numeric_limits<double>::infinity() :
+                std::abs(area - expectedArea) / expectedArea;
 
         t.ok(deviation <= libtess2Deviation, std::string{ "libtess2 deviation " } + formatPercent(deviation) +
                                                 " is less than " +


### PR DESCRIPTION
This should do the trick to fix #48 for now. 

At some point I think it would make sense to add an epsilon to these and all other floating point comparisons, but this commit fixes the undefined division by zero.

Also updates clang to 3.8 to be able to run `-fsanitize=undefined` on travis