### PR TITLE
remove unused this from lamba capture

### DIFF
--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -428,7 +428,7 @@ Earcut<N>::eliminateHoles(const Polygon& points, Node* outerNode) {
             queue.push_back(getLeftmost(list));
         }
     }
-    std::sort(queue.begin(), queue.end(), [this](const Node* a, const Node* b) {
+    std::sort(queue.begin(), queue.end(), [](const Node* a, const Node* b) {
         return a->x < b->x;
     });
 


### PR DESCRIPTION
With the upgrade to the newest Android NDK beta in https://github.com/mapbox/mapbox-gl-native/pull/9081. 
We are hitting the following warning:

```
error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
```

[Capturing](https://github.com/mapbox/mapbox-gl-native/pull/9081#issuecomment-303661431) from @kkaefer that this unused may be deleted.