### PR TITLE
Use ccache to speed up recompiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
   homebrew:
     packages:
       - ccache
+    update: true
 
 env:
   global:
@@ -118,12 +119,12 @@ matrix:
 
     # osx gcc
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode11
       env: BUILDTYPE=Release
       compiler: gcc
 
     # osx clang
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode11
       env: BUILDTYPE=Release
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ addons:
       - xorg-dev
       - libgl1-mesa-dev
       - ccache
+  homebrew:
+    packages:
+      - ccache
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: cpp
 
-sudo: false
-
-cache: apt
-
 before_install:
   - if [[ ${COVERITY_SCAN} == "1" ]]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca- ; fi
 
@@ -16,12 +12,12 @@ install:
 
 before_script:
   - eval "${MATRIX_EVAL}"
-  - ( mkdir -p build && cd build ; cmake .. -DCMAKE_BUILD_TYPE=${BUILDTYPE} -DEARCUT_WARNING_IS_ERROR=ON )
+  - ( mkdir -p build && cd build ; cmake .. -DCMAKE_BUILD_TYPE=${BUILDTYPE} -DEARCUT_WARNING_IS_ERROR=ON -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" )
   - if [[ -n $COVERITY_SCAN_TOKEN && ${COVERITY_SCAN} == "1" ]] ; then curl -s 'https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh' | bash || true ; fi
 
 script:
   - cd ${TRAVIS_BUILD_DIR}/build
-  - make -j2
+  - make -j4
   - ./tests
   - echo -e "travis_fold:start:COVERALLS folding starts"
   - if [[ -n $COVERALLS_REPO_TOKEN && ${COVERAGE} == "1" ]]; then
@@ -38,6 +34,7 @@ addons:
     packages: &shared_linux_packages
       - xorg-dev
       - libgl1-mesa-dev
+      - ccache
 
 env:
   global:
@@ -46,6 +43,13 @@ env:
     - COVERITY_SCAN_NOTIFICATION_EMAIL="4f7f3a820da643d180486972f68a251f.protect@whoisguard.com"
     - COVERITY_SCAN_BUILD_COMMAND_PREPEND="cov-configure --comptype g++ --compiler g++-7 --template && cd build"
     - COVERITY_SCAN_BUILD_COMMAND="make -j2"
+    - CCACHE_TEMPDIR=/tmp/.ccache-temp
+    - CCACHE_COMPRESS=1
+    - CCACHE_DIR=${HOME}/.ccache
+
+cache:
+  directories:
+    - ${HOME}/.ccache
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 
 script:
   - cd ${TRAVIS_BUILD_DIR}/build
-  - make -j4
+  - make -j2
   - ./tests
   - echo -e "travis_fold:start:COVERALLS folding starts"
   - if [[ -n $COVERALLS_REPO_TOKEN && ${COVERAGE} == "1" ]]; then
@@ -119,12 +119,12 @@ matrix:
 
     # osx gcc
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode8
       env: BUILDTYPE=Release
       compiler: gcc
 
     # osx clang
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode8
       env: BUILDTYPE=Release
       compiler: clang


### PR DESCRIPTION
This starts using ccache on travis. And posts its cache to be re-used between jobs. This means that the first builds (without cache) will be just as slow (refs #75). But once the caches (per job) are ready then re-compiles should be faster, depending on what was changed.