### PR TITLE
Do not run bench on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ script:
       coveralls-lcov --repo-token ${COVERALLS_REPO_TOKEN} coverage.info ;
     fi
   - echo -e "travis_fold:end:COVERALLS folding ends"
-  - ./bench
 
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,5 @@ build_script:
 
 test_script:
   - cd build
-  - if exist %configuration% (cd "%configuration%") 
+  - if exist %configuration% (cd "%configuration%")
   - call "tests.exe"
-  - call "bench.exe"


### PR DESCRIPTION
This doesn't seem to serve much purpose (we usually only check bench results when running it locally during optimization passes), so I'd rather have faster CI builds.