### PR TITLE
Add missing #include <stdexcept>

### DIFF
--- a/test/comparison/libtess2.hpp
+++ b/test/comparison/libtess2.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 #include <array>
+#include <stdexcept>
 
 template <typename Coord, typename Polygon>
 class Libtess2Tesselator {


### PR DESCRIPTION
Resolve the following compile error:

earcut.hpp/test/comparison/libtess2.hpp:48:24: error: ‘runtime_error’ is not a member of ‘std’
   48 |             throw std::runtime_error("tesselation failed");