### PR TITLE
Fix potential nullptr dereference in `Earcut<N>::sortLinked(Node* list)` when compiling with `-Wnull-dereference`

### DIFF
--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -616,7 +616,7 @@ Earcut<N>::sortLinked(Node* list) {
             p = q;
         }
 
-        tail->nextZ = nullptr;
+        if (tail) tail->nextZ = nullptr;
 
         if (numMerges <= 1) return list;
 


### PR DESCRIPTION
gcc reports a potential nullptr dereference on line 619 when compiling with `-Wnull-dereference`

```
                from /home/damian/projects/checks/earcut.hpp/test/fixtures/bad_diagonals.cpp:3:
/home/damian/projects/checks/earcut.hpp/include/mapbox/earcut.hpp: In member function ‘void mapbox::detail::Earcut<N>::indexCurve(mapbox::detail::Earcut<N>::Node*) [with N = unsigned int]’:
/home/damian/projects/checks/earcut.hpp/include/mapbox/earcut.hpp:619:21: warning: null pointer dereference [-Wnull-dereference]
  619 |         tail->nextZ = nullptr;
      |         ~~~~~~~~~~~~^~~~~~~~~
```

Looking at the code tail could be set to nullptr if list is set to nullptr.

While this is unlikely to occur at the moment a change elsewhere at a latter date could result in nullptr being passed.