### PR TITLE
Export earcut_hpp package and allow installation of the earcut.hpp header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$" OR CMAKE_COMPILER_IS_GNUCXX)
         check_cxx_compiler_flag("-fsanitize=undefined" HAVE_FLAG_SANITIZE_UNDEFINED)
         if(HAVE_FLAG_SANITIZE_UNDEFINED)
             target_compile_options(common INTERFACE "$<$<CONFIG:Debug>:-fsanitize=undefined>")
+            # TODO: Replace with target link option once we support CMake 3.13 
+            target_link_libraries(common INTERFACE "$<$<CONFIG:Debug>:-fsanitize=undefined>")
         endif()
     endif()
     add_compile_options()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,8 @@ file(GLOB LIBTESS2_SOURCE_FILES test/comparison/libtess2/*.c test/comparison/lib
 source_group(comparison/libtess2 FILES ${LIBTESS2_SOURCE_FILES})
 add_library(libtess2 ${LIBTESS2_SOURCE_FILES})
 target_compile_options(libtess2 PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:/wd4244 /wd4267>>
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>>
+    $<$<CXX_COMPILER_ID:MSVC>:/wd4244 /wd4267>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>
 )
 
 add_library(common INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(fixtures PUBLIC earcut_hpp libtess2)
 file(GLOB COMPARISON_SOURCE_FILES test/comparison/*.cpp test/comparison/*.hpp)
 source_group(comparison FILES ${COMPARISON_SOURCE_FILES})
 # this is interface since there is no cpp files in the comparison directory
-add_library(comparison INTERFACE ${COMPARISON_SOURCE_FILES})
+add_library(comparison INTERFACE)
 
 
 file(GLOB LIBTESS2_SOURCE_FILES test/comparison/libtess2/*.c test/comparison/libtess2/*.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,101 +1,131 @@
 cmake_minimum_required(VERSION 3.2)
-project(earcut_hpp)
+project(earcut_hpp LANGUAGES CXX C)
 
 option(EARCUT_BUILD_TESTS "Build the earcut test program" ON)
 option(EARCUT_BUILD_BENCH "Build the earcut benchmark program" ON)
 option(EARCUT_BUILD_VIZ "Build the earcut visualizer program" ON)
 option(EARCUT_WARNING_IS_ERROR "Treat warnings as errors" OFF)
 
-# dependencies
-if (EARCUT_BUILD_VIZ)
-    # OpenGL
-    # linux: xorg-dev libgl1-mesa-glx libgl1-mesa-dev
-    # windows: in the windows sdk
-    find_package(OpenGL REQUIRED)
-    include_directories(SYSTEM ${OPENGL_INCLUDE_DIRS})
-
-    # GLFW3
-    if(EXISTS "${PROJECT_SOURCE_DIR}/.gitmodules")
-        execute_process(
-                COMMAND             git submodule update --init --recursive
-                WORKING_DIRECTORY   ${PROJECT_SOURCE_DIR}
-                OUTPUT_QUIET
-                ERROR_QUIET
-        )
-    endif()
-    set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "Build the GLFW example programs" FORCE)
-    set(GLFW_BUILD_TESTS OFF CACHE BOOL "Build the GLFW test programs" FORCE)
-    set(GLFW_BUILD_DOCS OFF CACHE BOOL "Build the GLFW documentation" FORCE)
-    set(GLFW_INSTALL OFF CACHE BOOL "Generate installation target" FORCE)
-    add_subdirectory(glfw)
-    set(GLFW_LIBS glfw ${GLFW_LIBRARIES})
-    include_directories(SYSTEM "glfw/include")
-endif()
-
-# setup compiler flags for earcut
-set(CMAKE_CXX_STANDARD 11)
-if (NOT CMAKE_BUILD_TYPE)
+if (NOT CMAKE_BUILD_TYPE AND NOT GENERATOR_IS_MULTI_CONFIG)
     message(STATUS "No build type specified. Setting to 'Release'")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "The type of build." FORCE)
 endif()
+
+
+include(GNUInstallDirs)
+
+add_library(earcut_hpp INTERFACE)
+add_library(earcut_hpp::earcut_hpp ALIAS earcut_hpp)
+
+target_include_directories(earcut_hpp INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(earcut_hpp INTERFACE cxx_std_11)
+
+file(GLOB FIXTURE_SOURCE_FILES test/fixtures/*.cpp test/fixtures/*.hpp)
+source_group(fixtures FILES ${FIXTURE_SOURCE_FILES})
+add_library(fixtures OBJECT ${FIXTURE_SOURCE_FILES})
+target_compile_options(fixtures PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:/Od>")
+target_link_libraries(fixtures PUBLIC earcut_hpp libtess2)
+
+
+file(GLOB COMPARISON_SOURCE_FILES test/comparison/*.cpp test/comparison/*.hpp)
+source_group(comparison FILES ${COMPARISON_SOURCE_FILES})
+# this is interface since there is no cpp files in the comparison directory
+add_library(comparison INTERFACE ${COMPARISON_SOURCE_FILES})
+
+
+file(GLOB LIBTESS2_SOURCE_FILES test/comparison/libtess2/*.c test/comparison/libtess2/*.h)
+source_group(comparison/libtess2 FILES ${LIBTESS2_SOURCE_FILES})
+add_library(libtess2 ${LIBTESS2_SOURCE_FILES})
+target_compile_options(libtess2 PRIVATE "$<IF:$<CXX_COMPILER_ID:MSVC>,/wd4244;/wd4267,-w>")
+
+add_library(common INTERFACE)
+target_link_libraries(common INTERFACE libtess2 comparison fixtures)
+target_compile_options(common INTERFACE "$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-pipe;-Wall;-Wextra;-Wconversion;-Wpedantic>")
+
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$" OR CMAKE_COMPILER_IS_GNUCXX)
     if ("${CMAKE_CXX_FLAGS}" MATCHES "--coverage")
-        add_definitions(-DNDEBUG)
+        target_compile_definitions(common INTERFACE NDEBUG)
     else()
         include(CheckCXXCompilerFlag)
         check_cxx_compiler_flag("-fsanitize=undefined" HAVE_FLAG_SANITIZE_UNDEFINED)
         if(HAVE_FLAG_SANITIZE_UNDEFINED)
-            set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=undefined")
+            target_compile_options(common INTERFACE "$<$<CONFIG:Debug>:-fsanitize=undefined>")
         endif()
     endif()
-    add_compile_options("-pipe" "-Wall" "-Wextra" "-Wconversion" "-Wpedantic")
-    if (EARCUT_WARNING_IS_ERROR)
-        add_compile_options("-Werror")
-    endif()
+    add_compile_options()
+    target_compile_options(common INTERFACE "$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
     # optional: -march=native (builds with the optimizations available on the build machine (only for local use!))
-elseif(MSVC)
-    if (EARCUT_WARNING_IS_ERROR)
-        add_compile_options("/WX")
-    endif()
 endif()
 
-# earcut.hpp
-include_directories("include")
-
-file(GLOB FIXTURE_SOURCE_FILES test/fixtures/*.cpp test/fixtures/*.hpp)
-source_group(fixtures FILES ${FIXTURE_SOURCE_FILES})
-
-if (MSVC)
-    set_source_files_properties(${FIXTURE_SOURCE_FILES} PROPERTIES COMPILE_FLAGS "/Od")
+if (EARCUT_WARNING_IS_ERROR)
+    target_compile_options(common INTERFACE "$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
 endif()
-
-file(GLOB COMPARISON_SOURCE_FILES test/comparison/*.cpp test/comparison/*.hpp)
-source_group(comparison FILES ${COMPARISON_SOURCE_FILES})
-
-file(GLOB LIBTESS2_SOURCE_FILES test/comparison/libtess2/*.c test/comparison/libtess2/*.h)
-source_group(comparison\\libtess2 FILES ${LIBTESS2_SOURCE_FILES})
-
-if (MSVC)
-    set_source_files_properties(${LIBTESS2_SOURCE_FILES} PROPERTIES COMPILE_FLAGS "/wd4244 /wd4267")
-else()
-    set_source_files_properties(${LIBTESS2_SOURCE_FILES} PROPERTIES COMPILE_FLAGS "-w")
-endif()
-
-set(COMMON_SOURCE_FILES ${LIBTESS2_SOURCE_FILES} ${FIXTURE_SOURCE_FILES} ${COMPARISON_SOURCE_FILES})
-
-set(TESTS_SOURCE_FILES ${COMMON_SOURCE_FILES} test/tap.cpp test/tap.hpp test/test.cpp)
-set(BENCH_SOURCE_FILES ${COMMON_SOURCE_FILES} test/bench.cpp)
-set(VIZ_SOURCE_FILES ${COMMON_SOURCE_FILES} test/viz.cpp)
 
 if (EARCUT_BUILD_TESTS)
-    add_executable(tests ${TESTS_SOURCE_FILES})
-    target_link_libraries(tests ${Boost_LIBRARIES})
+    enable_testing()
+    add_executable(tests test/tap.cpp test/tap.hpp test/test.cpp $<TARGET_OBJECTS:fixtures>)
+    target_link_libraries(tests PRIVATE earcut_hpp common)
+    add_test(NAME earcut_tests COMMAND tests)
 endif()
 if (EARCUT_BUILD_BENCH)
-    add_executable(bench ${BENCH_SOURCE_FILES})
-    target_link_libraries(bench ${Boost_LIBRARIES})
+    add_executable(bench test/bench.cpp $<TARGET_OBJECTS:fixtures>)
+    target_link_libraries(bench PRIVATE earcut_hpp common)
 endif()
 if (EARCUT_BUILD_VIZ)
-    add_executable(viz ${VIZ_SOURCE_FILES})
-    target_link_libraries(viz ${Boost_LIBRARIES} ${GLFW_LIBS} ${OPENGL_LIBRARIES})
+    add_executable(viz test/viz.cpp $<TARGET_OBJECTS:fixtures>)
+
+    # Setup viz target
+    # OpenGL
+    # linux: xorg-dev libgl1-mesa-glx libgl1-mesa-dev
+    # windows: in the windows sdk
+    find_package(OpenGL REQUIRED)
+
+    # GLFW3
+    find_package(glfw3 QUIET) # try to use the system default
+    if (NOT glfw3_FOUND)
+        if(EXISTS "${PROJECT_SOURCE_DIR}/.gitmodules")
+            find_package(Git REQUIRED)
+            execute_process(
+                    COMMAND             ${GIT_EXECUTABLE} submodule update --init --recursive
+                    WORKING_DIRECTORY   ${PROJECT_SOURCE_DIR}
+                    OUTPUT_QUIET
+                    ERROR_QUIET
+            )
+        endif()
+
+        set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "Build the GLFW example programs" FORCE)
+        set(GLFW_BUILD_TESTS OFF CACHE BOOL "Build the GLFW test programs" FORCE)
+        set(GLFW_BUILD_DOCS OFF CACHE BOOL "Build the GLFW documentation" FORCE)
+        set(GLFW_INSTALL OFF CACHE BOOL "Generate installation target" FORCE)
+        add_subdirectory(glfw)
+    endif()
+    
+    target_compile_definitions(viz PRIVATE GL_SILENCE_DEPRECATION)
+    
+    # TODO: Using old variables for OpenGL package since they were added in CMake 3.8
+    target_link_libraries(viz PRIVATE earcut_hpp common glfw ${OPENGL_LIBRARIES})
+    target_include_directories(viz PRIVATE ${OPENGL_INCLUDE_DIR})
 endif()
+
+install(
+  DIRECTORY include/mapbox
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(TARGETS earcut_hpp EXPORT earcut_hpp-config)
+
+# Since there is two projects, we need to export into the parent directory
+export(
+  TARGETS earcut_hpp
+  NAMESPACE earcut_hpp::
+  FILE "${PROJECT_BINARY_DIR}/earcut_hpp-config.cmake"
+)
+
+install(EXPORT earcut_hpp-config
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/earcut_hpp"
+  NAMESPACE earcut_hpp::
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,12 @@ target_include_directories(earcut_hpp INTERFACE
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(earcut_hpp INTERFACE cxx_std_11)
+set(CMAKE_CXX_STANDARD 11)
+
+if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" GREATER 3.7)
+    # Allow C++11 requirements to propagate when using recent CMake versions
+    target_compile_features(earcut_hpp INTERFACE cxx_std_11)
+endif()
 
 file(GLOB FIXTURE_SOURCE_FILES test/fixtures/*.cpp test/fixtures/*.hpp)
 source_group(fixtures FILES ${FIXTURE_SOURCE_FILES})
@@ -44,13 +49,18 @@ add_library(comparison INTERFACE)
 file(GLOB LIBTESS2_SOURCE_FILES test/comparison/libtess2/*.c test/comparison/libtess2/*.h)
 source_group(comparison/libtess2 FILES ${LIBTESS2_SOURCE_FILES})
 add_library(libtess2 ${LIBTESS2_SOURCE_FILES})
-target_compile_options(libtess2 PRIVATE "$<IF:$<CXX_COMPILER_ID:MSVC>,/wd4244;/wd4267,-w>")
+target_compile_options(libtess2 PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/wd4244 /wd4267>>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>>
+)
 
 add_library(common INTERFACE)
-target_link_libraries(common INTERFACE libtess2 comparison fixtures)
+target_link_libraries(common INTERFACE libtess2 comparison)
 
 # optional: -march=native (builds with the optimizations available on the build machine (only for local use!))
-target_compile_options(common INTERFACE "$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-pipe;-Wall;-Wextra;-Wconversion;-Wpedantic>")
+target_compile_options(common INTERFACE
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-pipe -Wall -Wextra -Wconversion -Wpedantic>
+)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$" OR CMAKE_COMPILER_IS_GNUCXX)
     if ("${CMAKE_CXX_FLAGS}" MATCHES "--coverage")
@@ -69,7 +79,10 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$" OR CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 if (EARCUT_WARNING_IS_ERROR)
-    target_compile_options(common INTERFACE "$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
+    target_compile_options(common INTERFACE
+        $<$<CXX_COMPILER_ID:MSVC>:/WX>>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>>
+    )
 endif()
 
 if (EARCUT_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 file(GLOB FIXTURE_SOURCE_FILES test/fixtures/*.cpp test/fixtures/*.hpp)
 source_group(fixtures FILES ${FIXTURE_SOURCE_FILES})
 add_library(fixtures OBJECT ${FIXTURE_SOURCE_FILES})
-target_compile_options(fixtures PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:/Od>")
+target_compile_options(fixtures PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/Od>)
 
 # In CMake 3.12, use target_link_libraries(fixtures PUBLIC earcut_hpp libtess2).
 # Since we support down to CMake 3.2, we need to manually propagate usage requirements of earcut_hpp
@@ -71,17 +71,17 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$" OR CMAKE_COMPILER_IS_GNUCXX)
         include(CheckCXXCompilerFlag)
         check_cxx_compiler_flag("-fsanitize=undefined" HAVE_FLAG_SANITIZE_UNDEFINED)
         if(HAVE_FLAG_SANITIZE_UNDEFINED)
-            target_compile_options(common INTERFACE "$<$<CONFIG:Debug>:-fsanitize=undefined>")
+            target_compile_options(common INTERFACE $<$<CONFIG:Debug>:-fsanitize=undefined>)
             # TODO: Replace with target link option once we support CMake 3.13 
-            target_link_libraries(common INTERFACE "$<$<CONFIG:Debug>:-fsanitize=undefined>")
+            target_link_libraries(common INTERFACE $<$<CONFIG:Debug>:-fsanitize=undefined>)
         endif()
     endif()
 endif()
 
 if (EARCUT_WARNING_IS_ERROR)
     target_compile_options(common INTERFACE
-        $<$<CXX_COMPILER_ID:MSVC>:/WX>>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>>
+        $<$<CXX_COMPILER_ID:MSVC>:/WX>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,11 @@ file(GLOB FIXTURE_SOURCE_FILES test/fixtures/*.cpp test/fixtures/*.hpp)
 source_group(fixtures FILES ${FIXTURE_SOURCE_FILES})
 add_library(fixtures OBJECT ${FIXTURE_SOURCE_FILES})
 target_compile_options(fixtures PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:/Od>")
-target_link_libraries(fixtures PUBLIC earcut_hpp libtess2)
+
+# In CMake 3.12, use target_link_libraries(fixtures PUBLIC earcut_hpp libtess2).
+# Since we support down to CMake 3.2, we need to manually propagate usage requirements of earcut_hpp
+target_include_directories(fixtures PRIVATE "$<TARGET_PROPERTY:earcut_hpp,INTERFACE_INCLUDE_DIRECTORIES>")
+target_compile_features(fixtures PRIVATE "$<TARGET_PROPERTY:earcut_hpp,INTERFACE_COMPILE_FEATURES>")
 
 
 file(GLOB COMPARISON_SOURCE_FILES test/comparison/*.cpp test/comparison/*.hpp)
@@ -44,12 +48,16 @@ target_compile_options(libtess2 PRIVATE "$<IF:$<CXX_COMPILER_ID:MSVC>,/wd4244;/w
 
 add_library(common INTERFACE)
 target_link_libraries(common INTERFACE libtess2 comparison fixtures)
+
+# optional: -march=native (builds with the optimizations available on the build machine (only for local use!))
 target_compile_options(common INTERFACE "$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-pipe;-Wall;-Wextra;-Wconversion;-Wpedantic>")
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$" OR CMAKE_COMPILER_IS_GNUCXX)
     if ("${CMAKE_CXX_FLAGS}" MATCHES "--coverage")
+        # We disable debug code for the coverage so it won't see assertion and other things only enabled for debugging
         target_compile_definitions(common INTERFACE NDEBUG)
     else()
+        # Here we enable the undefined behavior sanitizer for the tests, benchmarks and the viz
         include(CheckCXXCompilerFlag)
         check_cxx_compiler_flag("-fsanitize=undefined" HAVE_FLAG_SANITIZE_UNDEFINED)
         if(HAVE_FLAG_SANITIZE_UNDEFINED)
@@ -58,9 +66,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$" OR CMAKE_COMPILER_IS_GNUCXX)
             target_link_libraries(common INTERFACE "$<$<CONFIG:Debug>:-fsanitize=undefined>")
         endif()
     endif()
-    add_compile_options()
-    target_compile_options(common INTERFACE "$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
-    # optional: -march=native (builds with the optimizations available on the build machine (only for local use!))
 endif()
 
 if (EARCUT_WARNING_IS_ERROR)


### PR DESCRIPTION
This pull request add support for `find_package(earcut_hpp)` to find this library, and add the include directories with `target_link_libraries(exec PRIVATE earcut_hpp::earcut_hpp)`. This works both in the source tree and the install tree. Speaking of install tree, this patch also allow the library to be installed into a prefix.

This makes earcut.hpp a fully packagable library that can be added into popular package managers such as conan and vcpkg.

Some other changes were made, I can revert those if they are not wanted:

 - Significantly accelerate building. I made the script so CMake won't rebuild the same source files for each executables. This was done by segregating the `libtess2`, `comparison` and `fixtures` into their own libraries and link to them.
 - Fast inclusion of `earcut_hpp` when adding the project via `add_subdirectory` or `FetchContent`. This was done by only searching for dependencies like glfw3 and only build glfw3 if the viz is enabled. Users will still have to set `EARCUT_BUILD_VIZ` to off when importing the library into their project.