### PR TITLE
Fix unused but set variable

### DIFF
--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -263,11 +263,8 @@ void Earcut<N>::earcutLinked(Node* ear, int pass) {
     Node* prev;
     Node* next;
 
-    int iterations = 0;
-
     // iterate through ears, slicing them one by one
     while (ear->prev != ear->next) {
-        iterations++;
         prev = ear->prev;
         next = ear->next;
 


### PR DESCRIPTION
Compiling with `-Wunused-but-set-variable` or by enabling `EARCUT_WARNING_IS_ERROR` in this case drops an error:
```
earcut.hpp/include/mapbox/earcut.hpp:266:9: error: variable 'iterations' set but not used [-Werror,-Wunused-but-set-variable]
    int iterations = 0;
        ^
```
Removing this variable will fix it. 