### PR TITLE
Include <cstdint> for uint32_t/int32_t

### DIFF
--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <utility>


### PR DESCRIPTION
Fixes failure to compile on GCC 15.