### PR TITLE
Optimizations: Node memory layout and Triangle struct

### DIFF
--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -34,13 +34,12 @@ public:
 
 private:
     struct Node {
-        Node(N index, double x_, double y_) : i(index), x(x_), y(y_) {}
+        Node(N index, double x_, double y_) : x(x_), y(y_), i(index), steiner(0) {}
         Node(const Node&) = delete;
         Node& operator=(const Node&) = delete;
         Node(Node&&) = delete;
         Node& operator=(Node&&) = delete;
 
-        const N i;
         const double x;
         const double y;
 
@@ -51,12 +50,16 @@ private:
         // z-order curve value
         int32_t z = 0;
 
+        // original index in polygon
+        const N i : (sizeof(N) * 8 - 1);
+
+        // indicates whether this is a steiner point
+        N steiner : 1;
+
         // previous and next nodes in z-order
         Node* prevZ = nullptr;
         Node* nextZ = nullptr;
 
-        // indicates whether this is a steiner point
-        bool steiner = false;
     };
 
     template <typename Ring> Node* linkedList(const Ring& points, const bool clockwise);


### PR DESCRIPTION
Bringing some optimizations to earcut:

* Change the memory layout of the Node object to reduce memory size (~30% smaller)
* Improve runtime speed by caching triangle coords in a struct that fits within a cache line


after (ns) | before (ns) | change | name
--- | --- | --- | ---
3639.09 | 3502.92 | 3.89% | `bad_hole`
309.23 | 299.4 | 3.28% | `building`
141.93 | 138.94 | 2.15% | `degenerate`
4982.33 | 5105.03 | -2.40% | `dude`
191.56 | 193.82 | -1.17% | `empty_square`
397645.67 | 440010.5 | -9.63% | `water`
314034.67 | 340645.83 | -7.81% | `water2`
13054.3 | 13607.89 | -4.07% | `water3`
1232.5 | 1251.44 | -1.51% | `water3b`
80921.71 | 77718.75 | 4.12% | `water4`
6449166.5 | 6848604.5 | -5.83% | `water_huge`
14539417 | 15063062.5 | -3.48% | `water_huge2`