### PR TITLE
avoid NaN in the hole sorting comparator

### DIFF
--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -561,9 +561,12 @@ typename Earcut<N>::Node* Earcut<N>::eliminateHoles(const Polygon& points, Node*
     std::sort(holeQueue.begin(), holeQueue.end(), [](const Node* a, const Node* b) {
         if (a->x != b->x) return a->x < b->x;
         if (a->y != b->y) return a->y < b->y;
-        const double aSlope = (a->next->y - a->y) / (a->next->x - a->x);
-        const double bSlope = (b->next->y - b->y) / (b->next->x - b->x);
-        return aSlope < bSlope;
+        const double adx = a->next->x - a->x, ady = a->next->y - a->y;
+        const double bdx = b->next->x - b->x, bdy = b->next->y - b->y;
+        const bool aDegenerate = adx == 0 && ady == 0;
+        const bool bDegenerate = bdx == 0 && bdy == 0;
+        if (aDegenerate != bDegenerate) return aDegenerate;
+        return ady * bdx < bdy * adx;
     });
 
     // block-bbox index for findHoleBridge, grown append-only as holes merge. Seed it with the


### PR DESCRIPTION
The slope tiebreak divides by the edge's dx, so a zero-length edge (coincident points that filterPoints has not yet removed) yields `NaN`.
 
In JS-world, Array#sort handles that , but for std::sort a comparator returning inconsistent results is undefined behavior (it must be a strict weak ordering; MSVC debug asserts on it, libc++ can crash).

Compare the slopes by cross-multiplication instead, which is exact for the same reason the division was (both dx are non-negative for leftmost points), and order zero-length edges first so the ordering stays strict.